### PR TITLE
Async support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 Version 0.2.0
 -------------
 
-To be released.
+Add async support.
 
 
 Version 0.1.1

--- a/nirum_http/__init__.py
+++ b/nirum_http/__init__.py
@@ -1,0 +1,4 @@
+from .http import HttpTransport
+
+__all__ = 'HttpTransport',
+__version__ = '0.2.0'

--- a/nirum_http/async_http.py
+++ b/nirum_http/async_http.py
@@ -1,0 +1,39 @@
+from aiohttp import ClientResponseError, ClientSession as Session
+from nirum.exc import UnexpectedNirumResponseError
+from nirum.transport import Transport
+
+from .util import url_endswith_slash
+
+__all__ = 'AsyncHttpTransport',
+
+
+class AsyncHttpTransport(Transport):
+
+    def __init__(self, url, session=None):
+        if session is None:
+            session = Session()
+        elif not isinstance(session, Session):
+            raise TypeError('session must be {0.__module__}.{0.__name__}, not '
+                            '{1!r}'.format(Session, session))
+        self.url = url_endswith_slash(url)
+        self.session = session
+
+    async def call(self,
+                   method_name,
+                   payload,
+                   service_annotations,
+                   method_annotations,
+                   parameter_annotations):
+        response = await self.session.post(
+            self.url,
+            params={'method': method_name},
+            headers={'Accept': 'application/json'},
+            json=payload
+        )
+        try:
+            content = await response.json()
+        except (ValueError, ClientResponseError):
+            raise UnexpectedNirumResponseError(
+                await response.text()  # TODO: encoding error?
+            )
+        return response.status == 200, content

--- a/nirum_http/http.py
+++ b/nirum_http/http.py
@@ -1,22 +1,10 @@
-from nirum.transport import Transport
 from nirum.exc import UnexpectedNirumResponseError
+from nirum.transport import Transport
 from requests import Session
-from six import string_types
-from six.moves import urllib
+
+from .util import url_endswith_slash
 
 __all__ = 'HttpTransport',
-__version__ = '0.2.0'
-
-
-def url_endswith_slash(url):
-    if not isinstance(url, string_types):
-        raise TypeError('url must be a string, not {0!r}'.format(url))
-    scheme, netloc, path, _, _ = urllib.parse.urlsplit(url)
-    if not (scheme and netloc):
-        raise ValueError("{} isn't URL.".format(url))
-    if not path.endswith('/'):
-        path += '/'
-    return urllib.parse.urlunsplit((scheme, netloc, path, '', ''))
 
 
 class HttpTransport(Transport):

--- a/nirum_http/util.py
+++ b/nirum_http/util.py
@@ -1,0 +1,15 @@
+from six import string_types
+from six.moves import urllib
+
+__all__ = "url_endswith_slash",
+
+
+def url_endswith_slash(url):
+    if not isinstance(url, string_types):
+        raise TypeError('url must be a string, not {0!r}'.format(url))
+    scheme, netloc, path, _, _ = urllib.parse.urlsplit(url)
+    if not (scheme and netloc):
+        raise ValueError("{} isn't URL.".format(url))
+    if not path.endswith('/'):
+        path += '/'
+    return urllib.parse.urlunsplit((scheme, netloc, path, '', ''))

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 
+from setuptools import find_packages
 from setuptools import setup, __version__ as setuptools_version
 
 
@@ -20,7 +21,8 @@ def readme(name='README.rst'):
 
 
 def get_version():
-    module_path = os.path.join(os.path.dirname(__file__), 'nirum_http.py')
+    module_path = os.path.join(os.path.dirname(__file__),
+                               'nirum_http', '__init__.py')
     module_file = open(module_path)
     try:
         module_code = module_file.read()
@@ -47,7 +49,7 @@ install_requires = [
 ]
 tests_require = [
     'flake8-import-order >= 0.12, < 1.0',
-    'flake8-import-order-spoqa >= 1.0.0, < 2.0.0',
+    'flake8-import-order-spoqa >= 1.0.1, < 2.0.0',
     'pytest >= 3.1.2, < 4.0.0',
     'pytest-flake8 >= 0.8.1, < 1.0.0',
     'requests-mock >= 1.3.0, < 1.4.0',
@@ -58,10 +60,19 @@ extras_require = {
 below35_requires = [
     'typing',
 ]
-
+async_require = [
+    'aiohttp',
+]
+async_test_require = [
+    'pytest-aiohttp >= 0.1.3, < 1.2.0',
+    'aiotools >= 0.4.3, < 0.5.0',
+]
 
 if 'bdist_wheel' not in sys.argv and sys.version_info < (3, 5):
     install_requires.extend(below35_requires)
+
+if sys.version_info >= (3, 5):
+    tests_require.extend(async_test_require)
 
 
 if tuple(map(int, setuptools_version.split('.'))) < (17, 1):
@@ -70,6 +81,7 @@ if tuple(map(int, setuptools_version.split('.'))) < (17, 1):
     extras_require.update({":python_version=='2.7'": below35_requires})
 else:
     extras_require.update({":python_version<'3.5'": below35_requires})
+    extras_require.update({":python_version>='3.5'": async_require})
 
 
 setup(
@@ -81,7 +93,7 @@ setup(
     author='Kang Hyojun',
     author_email='iam.kanghyojun' '@' 'gmail.com',
     license='MIT license',
-    py_modules=['nirum_http'],
+    packages=find_packages(),
     install_requires=install_requires,
     setup_requires=setup_requires,
     extras_require=extras_require

--- a/tests/async_http_test.py
+++ b/tests/async_http_test.py
@@ -1,0 +1,73 @@
+import asyncio
+import contextlib
+
+from aiohttp import ClientSession as Session, web
+from aiohttp.test_utils import unused_port
+from aiotools import async_ctx_manager
+from nirum.exc import UnexpectedNirumResponseError
+from pytest import raises
+
+from nirum_http.async_http import AsyncHttpTransport
+
+
+@async_ctx_manager
+async def new_session(method_name, callback):
+    loop = asyncio.get_event_loop()
+    port = unused_port()
+
+    def rpc_callback(request: web.Request):
+        if method_name == request.query.get("method"):
+            return callback(request)
+
+        return web.Response(status=404)
+
+    app = web.Application()
+    app.router.add_post('/', rpc_callback)
+    handler = app.make_handler(loop=loop)
+
+    base_url = f'http://127.0.0.1:{port}/'
+
+    server = await loop.create_server(handler, host="127.0.0.1", port=port)
+    with contextlib.closing(server):
+        session = Session()
+        t = AsyncHttpTransport(base_url, session)
+
+        try:
+            yield t
+        finally:
+            await app.cleanup()
+            server.close()
+
+
+async def test_call():
+    def callback(request):
+        return web.json_response({'_type': 'point', 'x': 1.0, 'top': 2.0})
+
+    method_name = 'hello_world'
+    async with new_session(method_name, callback) as t:
+        successful, result = await t.call(
+            method_name, payload={'name': 'John'},
+            service_annotations={},
+            method_annotations={},
+            parameter_annotations={}
+        )
+        assert successful
+        assert result == {'_type': 'point', 'x': 1.0, 'top': 2.0}
+
+
+async def test_unexpected_nirum_response_error():
+    def callback(request):
+        return web.Response(text='Error message')
+
+    method_name = 'hello_world'
+    async with new_session(method_name, callback) as t:
+        with raises(UnexpectedNirumResponseError) as exc_info:
+            await t.call(
+                method_name, payload={'name': 'John'},
+                service_annotations={},
+                method_annotations={},
+                parameter_annotations={}
+            )
+        exc = exc_info.value
+        assert exc.args == ('Error message',)
+        assert isinstance(exc.args[0], str)

--- a/tests/http_test.py
+++ b/tests/http_test.py
@@ -1,8 +1,9 @@
+from nirum.exc import UnexpectedNirumResponseError
 from pytest import fixture, raises
 from requests import Session
 from requests_mock import Adapter
 
-from nirum_http import HttpTransport, UnexpectedNirumResponseError
+from nirum_http import HttpTransport
 
 
 @fixture

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
     python3 setup.py --long-description | rst2html.py --strict
 
 [pytest]
-addopts = --ff --flake8 test.py
+addopts = --ff --flake8 tests
 
 [flake8]
 exclude = .env, .tox


### PR DESCRIPTION
확인 목록
---
- [ ] tox
- [x] pytest (python 3.6)
- [x] import order

tox
---
- [ ] py27: 테스트 실패 (`tests/async_http_test.py` 에서 `async` 키워드 사용)
- [ ] py34
- [ ] py35: `aiotools` 디펜던시가 python 3.6 버전 이상으로만 사용 가능
- [x] py36: tox, pytest 통과